### PR TITLE
Updates and Fix

### DIFF
--- a/AnimalsAreFunContinued.csproj
+++ b/AnimalsAreFunContinued.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net481</TargetFramework>
-    <LangVersion>9</LangVersion>
+    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <Title>Animals Are Fun! (Continued)</Title>
     <Version>1.5.3</Version>
@@ -38,6 +38,10 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4085" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AnimalsAreFunContinued.csproj
+++ b/AnimalsAreFunContinued.csproj
@@ -37,7 +37,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4085" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4104" />
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="System.Memory" Version="4.5.5" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />

--- a/AnimalsAreFunContinued.csproj
+++ b/AnimalsAreFunContinued.csproj
@@ -5,7 +5,7 @@
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <Title>Animals Are Fun! (Continued)</Title>
-    <Version>1.5.3</Version>
+    <Version>1.5.4</Version>
     <Authors>ColossalFossil</Authors>
     <Product>Animals Are Fun! (Continued)</Product>
     <Description>A RimWorld mod that allows your pawns to play fetch or go for a walk with your pets.</Description>

--- a/CacheController.cs
+++ b/CacheController.cs
@@ -1,0 +1,15 @@
+﻿using AnimalsAreFunContinued.Data;
+using RimWorld.Planet;
+
+namespace AnimalsAreFunContinued
+{
+    public class CacheController(World world) : WorldComponent(world)
+    {
+        public override void FinalizeInit()
+        {
+            AnimalCache.Clear();
+
+            base.FinalizeInit();
+        }
+    }
+}

--- a/Data/AnimalCache.cs
+++ b/Data/AnimalCache.cs
@@ -1,7 +1,4 @@
 ﻿using AnimalsAreFunContinued.Validators;
-using RimWorld;
-using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using Verse;

--- a/Data/AnimalCache.cs
+++ b/Data/AnimalCache.cs
@@ -64,5 +64,14 @@ namespace AnimalsAreFunContinued.Data
             IEnumerable<Thing> animals = GetAvailableAnimals(pawn.MapHeld);
             return GenClosest.ClosestThing_Global(pawn.Position, animals, 30f, animalValidator) as Pawn;
         }
+
+        public static void Clear()
+        {
+            if (_availableAnimals.Count > 0)
+            {
+                AnimalsAreFunContinued.Debug("clearing cached animal list for all maps");
+                _availableAnimals.Clear();
+            }
+        }
     }
 }

--- a/Data/AnimalCache.cs
+++ b/Data/AnimalCache.cs
@@ -14,7 +14,7 @@ namespace AnimalsAreFunContinued.Data
     public static class AnimalCache
     {
         private const int ExpirationTimeout = 1800;
-        private static readonly Dictionary<int, AnimalCacheKey> _availableAnimals = new();
+        private static readonly Dictionary<int, AnimalCacheKey> _availableAnimals = [];
 
         public static IEnumerable<Thing> GetAvailableAnimals(Map map)
         {
@@ -27,7 +27,7 @@ namespace AnimalsAreFunContinued.Data
                 IEnumerable<Thing> animals = (from animal in map.listerThings.ThingsMatching(ThingRequest.ForGroup(ThingRequestGroup.Pawn))
                                               where (animal as Pawn)?.def?.race?.Animal == true &&
                                                     animal.Faction != null
-                                              select animal) ?? new List<Thing>();
+                                              select animal) ?? [];
                 int expirationTick = currentTick + ExpirationTimeout;
 
                 if (updateExistingAnimalList)

--- a/GlobalTypes.cs
+++ b/GlobalTypes.cs
@@ -1,0 +1,4 @@
+﻿global using LocalTargetInfoDelegate = System.Func<Verse.LocalTargetInfo>;
+
+global using ConditionDelegate = System.Func<System.Boolean>;
+global using ConditionsDelegate = System.Collections.Generic.List<System.Func<System.Boolean>>;

--- a/JobDrivers/FetchItem.cs
+++ b/JobDrivers/FetchItem.cs
@@ -43,7 +43,7 @@ namespace AnimalsAreFunContinued.JobDrivers
             yield return jogBackToPawn;
 
             // wait for a moment
-            yield return AnimalActions.HoldPosition(120);
+            yield return AnimalActions.HoldPosition(90);
         }
     }
 }

--- a/JobDrivers/JobBase.cs
+++ b/JobDrivers/JobBase.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Verse;
 using Verse.AI;
 
@@ -6,24 +6,124 @@ namespace AnimalsAreFunContinued.JobDrivers
 {
     public abstract class JobBase : JobDriver
     {
-        public Action CreateNextToilActionDelegate(Toil toilToRepeat, Toil toilOnEnd, string? continueMessage = null, string? finishMessage = null) => delegate ()
+        public int? InteractiveTargetCurrentJobId = null;
+        public JobBase()
         {
-            Pawn animal = job.GetTarget(TargetIndex.B).Pawn;
-            if (Find.TickManager.TicksGame > startTick + job.def.joyDuration)
+            this.AddFinishAction((JobCondition _) =>
             {
-                if (finishMessage != null)
+                StopJobForTarget();
+            });
+        }
+
+        public Toil StartJobForTarget(JobDef jobDef, LocomotionUrgency locomotionUrgency, string? debugMessage = null) => 
+            StartJobForTarget(jobDef, null, locomotionUrgency, debugMessage);
+        public Toil StartJobForTarget(JobDef jobDef, LocalTargetInfoDelegate? getTargetA, LocomotionUrgency locomotionUrgency, string? debugMessage = null)
+        {
+            Pawn target = job.GetTarget(TargetIndex.B).Pawn;
+
+            return new()
+            {
+                initAction = () =>
                 {
-                    AnimalsAreFunContinued.Debug(finishMessage);
+                    if (target.jobs.curJob != null)
+                    {
+                        AnimalsAreFunContinued.Debug($"ending current job for target: {target}");
+                        target.jobs.EndCurrentJob(JobCondition.QueuedNoLongerValid);
+                    }
+
+                    target.jobs.StopAll();
+                    Job targetsNewJob = getTargetA != null ? JobMaker.MakeJob(jobDef, getTargetA(), pawn) : JobMaker.MakeJob(jobDef, pawn);
+                    targetsNewJob.locomotionUrgency = (LocomotionUrgency)locomotionUrgency;
+                    InteractiveTargetCurrentJobId = targetsNewJob.loadID;
+                    target.jobs.StartJob(targetsNewJob);
+
+                    if (debugMessage != null)
+                    {
+                        AnimalsAreFunContinued.Debug(debugMessage);
+                    }
+                },
+                defaultCompleteMode = ToilCompleteMode.Instant
+            };
+        }
+
+        public Toil EndJobForTarget(string? debugMessage = null) => new()
+        {
+            initAction = () =>
+            {
+                if (InteractiveTargetCurrentJobId != null)
+                {
+                    Pawn target = job.GetTarget(TargetIndex.B).Pawn;
+                    if (target.jobs.curJob.loadID == InteractiveTargetCurrentJobId)
+                    {
+                        target.jobs.EndCurrentJob(JobCondition.Succeeded);
+                    }
+
+                    InteractiveTargetCurrentJobId = null;
+                    if (debugMessage != null)
+                    {
+                        AnimalsAreFunContinued.Debug(debugMessage);
+                    }
                 }
-                animal.jobs.EndCurrentJob(JobCondition.Succeeded);
-                JumpToToil(toilOnEnd);
+            },
+            defaultCompleteMode = ToilCompleteMode.Instant
+        };
+
+        public void StopJobForTarget()
+        {
+            if (InteractiveTargetCurrentJobId != null)
+            {
+                Pawn target = job.GetTarget(TargetIndex.B).Pawn;
+                if (target.jobs.curJob.loadID == InteractiveTargetCurrentJobId)
+                {
+                    target.jobs.EndCurrentJob(JobCondition.Succeeded);
+                }
+
+                InteractiveTargetCurrentJobId = null;
+            }
+        }
+
+        public bool WaitForJobDuration() => Find.TickManager.TicksGame < startTick + job.def.joyDuration;
+        public bool InteractiveTargetHasJob()
+        {
+            if (InteractiveTargetCurrentJobId == null)
+            {
+                return true;
             }
 
-            if (continueMessage != null)
+            Pawn target = job.GetTarget(TargetIndex.B).Pawn;
+            if (target.CurJob.loadID != InteractiveTargetCurrentJobId)
             {
-                AnimalsAreFunContinued.Debug(continueMessage);
+                InteractiveTargetCurrentJobId = null;
             }
-            JumpToToil(toilToRepeat);
+            return InteractiveTargetCurrentJobId != null;
+        }
+
+        public Toil RepeatToilOnCondition(Toil toilToRepeat, ConditionDelegate repeatOnCondition, string? repeatMessage = null) =>
+            RepeatToilOnCondition(toilToRepeat, [repeatOnCondition], repeatMessage);
+        public Toil RepeatToilOnCondition(Toil toilToRepeat, ConditionsDelegate repeatOnAllConditions, string? repeatMessage = null) => new()
+        {
+            initAction = () =>
+            {
+                bool repeatToil = true;
+                foreach (ConditionDelegate condition in repeatOnAllConditions)
+                {
+                    if (!repeatToil)
+                    {
+                        break;
+                    }
+                    repeatToil = condition();
+                }
+
+                if (repeatToil)
+                {
+                    if (repeatMessage != null)
+                    {
+                        AnimalsAreFunContinued.Debug(repeatMessage);
+                    }
+                    JumpToToil(toilToRepeat);
+                }
+            },
+            defaultCompleteMode = ToilCompleteMode.Instant
         };
     }
 }

--- a/JobDrivers/PathableJobBase.cs
+++ b/JobDrivers/PathableJobBase.cs
@@ -10,7 +10,7 @@ namespace AnimalsAreFunContinued.JobDrivers
     {
         public List<LocalTargetInfo>? Path = null;
 
-        public Func<LocalTargetInfo> CreateNextWaypointDelegate(bool preserveStack = false) => delegate ()
+        public LocalTargetInfoDelegate CreateNextWaypointDelegate(bool preserveStack = false) => delegate ()
         {
             return PullNextWaypoint(preserveStack);
         };

--- a/JobDrivers/WalkPet.cs
+++ b/JobDrivers/WalkPet.cs
@@ -33,7 +33,7 @@ namespace AnimalsAreFunContinued.JobDrivers
 
             // walk more with pet
             Toil goBackToAnimal = PawnActions.WalkToPet(this, LocomotionUrgency.Jog);
-            yield return PawnActions.WalkToNextWaypoint(this, CreateNextToilActionDelegate(
+            yield return PawnActions.WalkToNextWaypoint(CreateNextToilActionDelegate(
                 walkToWaypoint,
                 goBackToAnimal,
                 $"pawn is continuing walk with animal: {pawn} => {animal.Name}",

--- a/JobDrivers/WalkPet.cs
+++ b/JobDrivers/WalkPet.cs
@@ -1,4 +1,5 @@
-﻿using AnimalsAreFunContinued.Toils;
+using AnimalsAreFunContinued.Toils;
+using RimWorld;
 using System.Collections.Generic;
 using Verse;
 using Verse.AI;
@@ -27,24 +28,24 @@ namespace AnimalsAreFunContinued.JobDrivers
             // say hello to animal
             yield return PawnActions.TalkToPet(this);
 
+            // pet should start to follow pawn
+            yield return StartJobForTarget(JobDefOf.Follow, LocomotionUrgency.Walk, $"animal is following pawn: {animal.Name} => {pawn}");
+
             // walk with pet
             Toil walkToWaypoint = PawnActions.WalkToWaypoint(this, CreateNextWaypointDelegate());
             yield return walkToWaypoint;
 
-            // walk more with pet
-            Toil goBackToAnimal = PawnActions.WalkToPet(this, LocomotionUrgency.Jog);
-            yield return PawnActions.WalkToNextWaypoint(CreateNextToilActionDelegate(
-                walkToWaypoint,
-                goBackToAnimal,
-                $"pawn is continuing walk with animal: {pawn} => {animal.Name}",
-                $"pawn is ending walk with animal: {pawn} => {animal.Name}"
-            ));
+            // walk more with pet, until job has finished
+            yield return RepeatToilOnCondition(walkToWaypoint, [WaitForJobDuration, InteractiveTargetHasJob], $"pawn is continuing walk with animal: {pawn} => {animal.Name}");
 
             // go back to animal
-            yield return goBackToAnimal;
+            yield return PawnActions.WalkToPet(this, LocomotionUrgency.Jog);
+
+            // pet should no longer follow
+            yield return EndJobForTarget($"animal is no longer following pawn: {animal.Name} => {pawn}");
 
             // say goodbye to pet
-            yield return PawnActions.TalkToPet(this, LocomotionUrgency.Jog);
+            yield return PawnActions.TalkToPet(this);
         }
     }
 }

--- a/JoyGivers/WantToPlayFetch.cs
+++ b/JoyGivers/WantToPlayFetch.cs
@@ -10,15 +10,15 @@ namespace AnimalsAreFunContinued.JoyGivers
     {
         public override Job? TryGiveJob(Pawn pawn)
         {
-            if (!AvailabilityChecks.WillPawnEnjoyPlayingOutside(pawn))
-            {
-                return null;
-            }
-
             Pawn? animal = AnimalCache.GetAvailableAnimal(pawn);
             if (animal == null)
             {
                 AnimalsAreFunContinued.Debug($"no valid animal found");
+                return null;
+            }
+
+            if (!AvailabilityChecks.WillPawnEnjoyPlayingOutside(pawn))
+            {
                 return null;
             }
 

--- a/JoyGivers/WantToWalkPet.cs
+++ b/JoyGivers/WantToWalkPet.cs
@@ -10,15 +10,15 @@ namespace AnimalsAreFunContinued.JoyGivers
     {
         public override Job? TryGiveJob(Pawn pawn)
         {
-            if (!AvailabilityChecks.WillPawnEnjoyPlayingOutside(pawn))
-            {
-                return null;
-            }
-
             Pawn? animal = AnimalCache.GetAvailableAnimal(pawn);
             if (animal == null)
             {
                 AnimalsAreFunContinued.Debug($"no valid animal found");
+                return null;
+            }
+
+            if (!AvailabilityChecks.WillPawnEnjoyPlayingOutside(pawn))
+            {
                 return null;
             }
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ Spend time and have fun with your pets! This mod lets your pawns play fetch or g
 will gain a little animal skill as well. This mod is a continuation of the
 [Animals are fun mod by Revolus](https://steamcommunity.com/sharedfiles/filedetails/?id=2108362126).
 
-This mod will only support versions 1.5 and forward of RimWorld. If you are running an older version of RimWorld, you 
+This mod currently only supports version 1.5 of RimWorld. If you are running an older version of RimWorld, you 
 can download the original mod this was derived from found [here](https://steamcommunity.com/sharedfiles/filedetails/?id=2108362126).
 
-This mod contains no dependencies and **can be added or removed at any time**. This mod does not use the game save file to
-store data. The source code is automatically bundled when compiling this project and should be included any copies that
-are distributed or modified to adhere to the GNU LGPL v2.1 license of the original mod.
+This mod contains no dependencies and **can be added or removed at any time**. If a save file contains a pawn or animal that
+is assigned a job from this mod, you may see an error when loading the save file. However, the error will automatically correct
+and will not be displayed on future saves. The source code is automatically bundled when compiling this project and should be
+included any copies that are distributed or modified to adhere to the GNU LGPL v2.1 license of the original mod.
 
 Translations are supported for this mod, but should be maintained and distributed in their own mod packages. Both DefInjected
 and Keyed translations are supported.
@@ -30,7 +31,7 @@ AnimalsAreFunContinued folder from ModPackageFolder into your local RimWorld mod
 Here are some high-level notes of the various files and classes:
 
 - Any user configurable settings should be added to the Settings class and set to be configured in the AnimalsAreFunContinued class
-- Logic for JobDriver or JoyGiver for pass/fail checks should be placed in the EligibilityFlags class
+- Logic for JobDriver or JoyGiver for pass/fail checks should be placed in the Validators folder
 - Try to keep JobDrivers, JoyGivers and Toils in separate classes
 
 ## Built With

--- a/Toils/PawnActions.cs
+++ b/Toils/PawnActions.cs
@@ -98,7 +98,7 @@ namespace AnimalsAreFunContinued.Toils
             return walkToWaypoint;
         }
 
-        public static Toil WalkToNextWaypoint(JobBase jobDriver, Action nextToilAction) => new()
+        public static Toil WalkToNextWaypoint(Action nextToilAction) => new()
         {
             initAction = () =>
             {


### PR DESCRIPTION
This PR continues to simplify job driver and the handoff between the pawn and animal job handler. It also addresses an issue where when reloading the world without closing the game client would cause errors due to invalidating the cache system.

- C# was updated to version 12 - global using statements for type aliases are now usable
- The toil steps for a job have been heavily simplified and is now easy to follow when reading the code
- Pawns will now check if they would enjoy playing outside before checking for available animals. This prepares us for indoor animal searches in the future.
- A world component has been set up (CacheController) to invalidate any caches set up on world load
- README has been slightly cleaned up to prepare for future updates (backports to earlier versions will be coming after new content)