### PR TITLE
Fix penned animals bug

### DIFF
--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -7,6 +7,9 @@ namespace AnimalsAreFunContinued
 {
     public class AnimalsAreFunContinued : Mod
     {
+        private Rect _scrollRegion = new(0f, 0f, 500f, 9001f);
+        private Vector2 _scrollPosition;
+
         public AnimalsAreFunContinued(ModContentPack content) : base(content)
         {
             GetSettings<Settings>();
@@ -30,48 +33,70 @@ namespace AnimalsAreFunContinued
 
         public override void DoSettingsWindowContents(Rect inRect)
         {
-            Listing_Standard listingStandard = new();
-            listingStandard.Begin(inRect);
+            Widgets.BeginScrollView(inRect, ref _scrollPosition, _scrollRegion);
+            Listing_Standard listingStandard = new() { maxOneColumn = true };
+            listingStandard.Begin(_scrollRegion);
+            
+            float gapSizeSmall = 0.6f;
+            float gapSizeLarge = 1.4f;
 
             /* Requirements */
-            listingStandard.Label("RequirementsCategory".Translate());
-            listingStandard.Gap(Text.LineHeight * 0.8f);
+            ShowLabel(listingStandard, "RequirementsCategory");
+            ShowGapLine(listingStandard, gapSizeSmall);
 
-            listingStandard.Label("MinConsciousness".Translate(FormatPercent(Settings.MinConsciousness)));
-            Settings.MinConsciousness = listingStandard.Slider(Settings.MinConsciousness, 0.1f, 1);
-            listingStandard.Label("MinMoving".Translate(FormatPercent(Settings.MinMoving)));
-            Settings.MinMoving = listingStandard.Slider(Settings.MinMoving, 0.1f, 1);
-            listingStandard.Label("MaxBodySize".Translate(FormatPercent(Settings.MaxBodySize)));
-            Settings.MaxBodySize = listingStandard.Slider(Settings.MaxBodySize, 0.01f, 5);
-            listingStandard.Label("MaxWildness".Translate(FormatPercent(Settings.MaxWildness)));
-            Settings.MaxWildness = listingStandard.Slider(Settings.MaxWildness, 0.1f, 1);
-            listingStandard.Gap(Text.LineHeight * 1.6f);
+            Settings.MinConsciousness = ShowSlider(listingStandard, "MinConsciousness", Settings.MinConsciousness, 0.1f, 1);
+            Settings.MinMoving = ShowSlider(listingStandard, "MinMoving", Settings.MinMoving, 0.1f, 1);
+            Settings.MaxBodySize = ShowSlider(listingStandard, "MaxBodySize", Settings.MaxBodySize, 0.1f, 1);
+            Settings.MaxWildness = ShowSlider(listingStandard, "MaxWildness", Settings.MaxWildness, 0.1f, 1);
+            ShowGap(listingStandard, gapSizeLarge);
 
             /* Experimental */
-            listingStandard.Label("ExperimentalCategory".Translate());
-            listingStandard.Gap(Text.LineHeight * 0.8f);
+            ShowLabel(listingStandard, "ExperimentalCategory");
+            ShowGapLine(listingStandard, gapSizeSmall);
 
-            listingStandard.CheckboxLabeled("MustBeCute".Translate(), ref Settings.MustBeCute, "MustBeCuteTooltip".Translate());
-            listingStandard.CheckboxLabeled("AllowHumanLike".Translate(), ref Settings.AllowHumanLike, "AllowHumanLikeTooltip".Translate());
-            listingStandard.CheckboxLabeled("AllowExoticPets".Translate(), ref Settings.AllowExoticPets, "AllowExoticPetsTooltip".Translate());
-            listingStandard.CheckboxLabeled("AllowCrossFaction".Translate(), ref Settings.AllowCrossFaction, "AllowCrossFactionTooltip".Translate());
-            listingStandard.CheckboxLabeled("AllowNonColonist".Translate(), ref Settings.AllowNonColonist, "AllowNonColonistTooltip".Translate()); 
-            listingStandard.Gap(Text.LineHeight * 1.6f);
+            ShowCheckbox(listingStandard, "MustBeCute", ref Settings.MustBeCute, "MustBeCuteTooltip");
+            ShowCheckbox(listingStandard, "AllowHumanLike", ref Settings.AllowHumanLike, "AllowHumanLikeTooltip");
+            ShowCheckbox(listingStandard, "AllowExoticPets", ref Settings.AllowExoticPets, "AllowExoticPetsTooltip");
+            ShowCheckbox(listingStandard, "AllowCrossFaction", ref Settings.AllowCrossFaction, "AllowCrossFactionTooltip");
+            ShowCheckbox(listingStandard, "AllowNonColonist", ref Settings.AllowNonColonist, "AllowNonColonistTooltip");
+            ShowGap(listingStandard, gapSizeLarge);
 
             /* Debugging */
-            listingStandard.Label("DebuggingCategory".Translate());
-            listingStandard.Gap(Text.LineHeight * 0.8f);
+            ShowLabel(listingStandard, "DebuggingCategory");
+            ShowGapLine(listingStandard, gapSizeSmall);
 
-            listingStandard.CheckboxLabeled("ShowDebugMessages".Translate(), ref Settings.ShowDebugMessages);
-            if (listingStandard.ButtonTextLabeled(string.Empty, "ResetToDefaults".Translate()))
+            ShowCheckbox(listingStandard, "ShowDebugMessages", ref Settings.ShowDebugMessages);
+            if (ShowButton(listingStandard, "Reset", "ResetToDefaults"))
             {
                 Settings.ResetToDefaults();
             }
 
             listingStandard.End();
+            Widgets.EndScrollView();
+            _scrollRegion = _scrollRegion with
+            {
+                height = listingStandard.curY + 50f,
+                width = inRect.width - GUI.skin.verticalScrollbar.fixedWidth - 10f
+            };
         }
 
         private static string FormatPercent(float value) => $"{(value * 100):0.00}";
+
+        private static bool ShowButton(Listing_Standard listingStandard, string buttonText, string labelName) => listingStandard.ButtonTextLabeled(labelName.Translate(), buttonText.Translate());
+        private static void ShowCheckbox(Listing_Standard listingStandard, string labelName, ref bool value) => listingStandard.CheckboxLabeled(labelName.Translate(), ref value, null);
+        private static void ShowCheckbox(Listing_Standard listingStandard, string labelName, ref bool value, string tooltipName) => listingStandard.CheckboxLabeled(labelName.Translate(), ref value, tooltipName.Translate());
+        private static void ShowGap(Listing_Standard listingStandard, float gapSize) => listingStandard.Gap(Text.LineHeight * gapSize);
+        private static void ShowGapLine(Listing_Standard listingStandard, float gapSize)
+        {
+            listingStandard.GapLine(2.0f);
+            ShowGap(listingStandard, gapSize);
+        }
+        private static Rect ShowLabel(Listing_Standard listingStandard, string labelName) => listingStandard.Label(labelName.Translate());
+        private static float ShowSlider(Listing_Standard listingStandard, string labelName, float value, float min, float max)
+        {
+            listingStandard.Label(labelName.Translate(FormatPercent(value)));
+            return listingStandard.Slider(value, min, max);
+        }
 
         public override string SettingsCategory() => "Animals_are_fun_Continued".Translate();
     }

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -45,13 +45,13 @@ namespace AnimalsAreFunContinued
             Settings.MaxBodySize = listingStandard.Slider(Settings.MaxBodySize, 0.01f, 5);
             listingStandard.Label("MaxWildness".Translate(FormatPercent(Settings.MaxWildness)));
             Settings.MaxWildness = listingStandard.Slider(Settings.MaxWildness, 0.1f, 1);
-            listingStandard.CheckboxLabeled("MustBeCute".Translate() , ref Settings.MustBeCute, "MustBeCuteTooltip".Translate());
             listingStandard.Gap(Text.LineHeight * 1.6f);
 
             /* Experimental */
             listingStandard.Label("ExperimentalCategory".Translate());
             listingStandard.Gap(Text.LineHeight * 0.8f);
 
+            listingStandard.CheckboxLabeled("MustBeCute".Translate(), ref Settings.MustBeCute, "MustBeCuteTooltip".Translate());
             listingStandard.CheckboxLabeled("AllowHumanLike".Translate(), ref Settings.AllowHumanLike, "AllowHumanLikeTooltip".Translate());
             listingStandard.CheckboxLabeled("AllowExoticPets".Translate(), ref Settings.AllowExoticPets, "AllowExoticPetsTooltip".Translate());
             listingStandard.CheckboxLabeled("AllowCrossFaction".Translate(), ref Settings.AllowCrossFaction, "AllowCrossFactionTooltip".Translate());

--- a/AnimalsAreFunContinued.csproj
+++ b/AnimalsAreFunContinued.csproj
@@ -5,7 +5,7 @@
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <Title>Animals Are Fun! (Continued)</Title>
-    <Version>1.5.5</Version>
+    <Version>1.5.7</Version>
     <Authors>ColossalFossil</Authors>
     <Product>Animals Are Fun! (Continued)</Product>
     <Description>A RimWorld mod that allows your pawns to play fetch or go for a walk with your pets.</Description>

--- a/Languages/English/Keyed/Translations.xml
+++ b/Languages/English/Keyed/Translations.xml
@@ -16,7 +16,7 @@
   <MinConsciousness>Min. consciousness ({0}%)</MinConsciousness>
   <MinMoving>Min. moving ({0}%)</MinMoving>
   <MustBeCute>Must be cute</MustBeCute>
-  <MustBeCuteTooltip>Only play with or walk nuzzling animals</MustBeCuteTooltip>
+  <MustBeCuteTooltip>Only play with or walk nuzzling animals. WARNING: Do not turn this off unless your have a very large penned in area or you have a mod that allows you teach zoning rules to any animal.</MustBeCuteTooltip>
   <RequirementsCategory>Requirements:</RequirementsCategory>
   <ResetToDefaults>Reset To Defaults</ResetToDefaults>
   <ShowDebugMessages>Show debug messages</ShowDebugMessages>

--- a/Languages/English/Keyed/Translations.xml
+++ b/Languages/English/Keyed/Translations.xml
@@ -18,6 +18,7 @@
   <MustBeCute>Must be cute</MustBeCute>
   <MustBeCuteTooltip>Only play with or walk nuzzling animals. WARNING: Do not turn this off unless your have a very large penned in area or you have a mod that allows you teach zoning rules to any animal.</MustBeCuteTooltip>
   <RequirementsCategory>Requirements:</RequirementsCategory>
-  <ResetToDefaults>Reset To Defaults</ResetToDefaults>
+  <ResetToDefaults>Reset all settings to defaults</ResetToDefaults>
+  <Reset>Reset</Reset>
   <ShowDebugMessages>Show debug messages</ShowDebugMessages>
 </LanguageData>

--- a/Validators/AvailabilityChecks.cs
+++ b/Validators/AvailabilityChecks.cs
@@ -93,7 +93,7 @@ namespace AnimalsAreFunContinued.Validators
                 return false;
             }
 
-            if (!Settings.MustBeCute && race.nuzzleMtbHours < 0f)
+            if (Settings.MustBeCute && race.nuzzleMtbHours < 0f)
             {
                 reason = "not cute";
                 return false;


### PR DESCRIPTION
The purpose of this PR is to correct a bug where the Must Be Cute setting was being evaluated incorrectly, causing penned animals to be valid animals to play with. As soon as the penned animal hits the boundary that the pawn can cross but the animal cannot, the animal will stop while the pawn continues.

The preferences panel was updated to include a scroll bar and some boiler plate wrapped up into static functions. The Must Be Cute setting has been moved to the experimental section and the tooltip added to include a warning.