### PR TITLE
Fix for checking for path before the job starts

### DIFF
--- a/AnimalsAreFunContinued.csproj
+++ b/AnimalsAreFunContinued.csproj
@@ -5,7 +5,7 @@
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <Title>Animals Are Fun! (Continued)</Title>
-    <Version>1.5.7</Version>
+    <Version>1.5.8</Version>
     <Authors>ColossalFossil</Authors>
     <Product>Animals Are Fun! (Continued)</Product>
     <Description>A RimWorld mod that allows your pawns to play fetch or go for a walk with your pets.</Description>

--- a/JobDrivers/PathableJobBase.cs
+++ b/JobDrivers/PathableJobBase.cs
@@ -8,65 +8,12 @@ namespace AnimalsAreFunContinued.JobDrivers
 {
     public abstract class PathableJobBase : JobBase
     {
-        public List<LocalTargetInfo>? Path = null;
+        public List<LocalTargetInfo> Path = null!;
 
         public LocalTargetInfoDelegate CreateNextWaypointDelegate(bool preserveStack = false) => delegate ()
         {
             return PullNextWaypoint(preserveStack);
         };
-
-        public bool FindOutsideWalkingPath()
-        {
-            try
-            {
-                Pawn animal = job.GetTarget(TargetIndex.B).Pawn;
-                if (
-                    FindWalkingDestination(pawn, animal, out IntVec3 walkingDestination) &&
-                    WalkPathFinder.TryFindWalkPath(pawn, walkingDestination, out List<IntVec3> path)
-                )
-                {
-                    Path = new List<LocalTargetInfo>(path.Count);
-                    for (int pathIndex = 0; pathIndex < path.Count; pathIndex++)
-                    {
-                        Path.Add(path[pathIndex]);
-                    }
-                    return true;
-                }
-
-                Path = null;
-                return false;
-            }
-            catch (Exception ex)
-            {
-                AnimalsAreFunContinued.LogError($"An error occurred in FindOutsideWalkingPath(). {ex.Message}");
-                Path = null;
-                return false;
-            }
-        }
-
-        private static bool FindWalkingDestination(Pawn pawn, Pawn animal, out IntVec3 walkingDestination)
-        {
-            IntVec3 potentialDestination = new();
-            bool CellGoodForWalking(IntVec3 cell)
-            {
-                Map map = animal.MapHeld;
-                return !PawnUtility.KnownDangerAt(cell, map, pawn) &&
-                        !cell.GetTerrain(map).avoidWander &&
-                        cell.Standable(map) &&
-                        !cell.Roofed(map);
-            };
-
-            bool RegionGoodForWalking(Region region) =>
-                 region.Room.PsychologicallyOutdoors &&
-                 !region.IsForbiddenEntirely(animal) &&
-                 !region.IsForbiddenEntirely(pawn) &&
-                 region.TryFindRandomCellInRegionUnforbidden(animal, CellGoodForWalking, out potentialDestination) &&
-                 !potentialDestination.IsForbidden(pawn);
-
-            bool isValidDestination = CellFinder.TryFindClosestRegionWith(animal.GetRegion(), TraverseParms.For(animal), RegionGoodForWalking, 100, out _);
-            walkingDestination = potentialDestination;
-            return isValidDestination;
-        }
 
         private LocalTargetInfo PullNextWaypoint(bool preserveStack = false)
         {

--- a/JobDrivers/PlayFetch.cs
+++ b/JobDrivers/PlayFetch.cs
@@ -9,21 +9,17 @@ namespace AnimalsAreFunContinued.JobDrivers
 {
     public class PlayFetch : PathableJobBase
     {
-        public override bool TryMakePreToilReservations(bool errorOnFailed) =>
-            pawn.Reserve(job.GetTarget(TargetIndex.B), job, errorOnFailed: errorOnFailed);
+        public override bool TryMakePreToilReservations(bool errorOnFailed)
+        {
+            Path = job.targetQueueA;
+            return pawn.Reserve(job.GetTarget(TargetIndex.B), job, errorOnFailed: errorOnFailed);
+        }
 
         public override IEnumerable<Toil> MakeNewToils()
         {
             string pawnName = FormatLog.PawnName(pawn);
             Pawn animal = job.GetTarget(TargetIndex.B).Pawn;
             string animalName = FormatLog.PawnName(animal);
-
-            // load the walking path
-            if (!FindOutsideWalkingPath())
-            {
-                AnimalsAreFunContinued.LogWarning($"{pawnName} wanted to play fetch with {animalName}, but could not find a valid walking path.");
-                yield break;
-            }
 
             // initial go to animal
             yield return PawnActions.WalkToPet(this, LocomotionUrgency.Jog);

--- a/JobDrivers/WalkPet.cs
+++ b/JobDrivers/WalkPet.cs
@@ -8,21 +8,17 @@ namespace AnimalsAreFunContinued.JobDrivers
 {
     public class WalkPet : PathableJobBase
     {
-        public override bool TryMakePreToilReservations(bool errorOnFailed) =>
-            pawn.Reserve(job.GetTarget(TargetIndex.B), job, errorOnFailed: errorOnFailed);
+        public override bool TryMakePreToilReservations(bool errorOnFailed)
+        {
+            Path = job.targetQueueA;
+            return pawn.Reserve(job.GetTarget(TargetIndex.B), job, errorOnFailed: errorOnFailed);
+        }
 
         public override IEnumerable<Toil> MakeNewToils()
         {
             string pawnName = FormatLog.PawnName(pawn);
             Pawn animal = job.GetTarget(TargetIndex.B).Pawn;
             string animalName = FormatLog.PawnName(animal);
-
-            // load the walking path
-            if (!FindOutsideWalkingPath())
-            {
-                AnimalsAreFunContinued.LogWarning($"{pawnName} wanted to for a walk with {animalName}, but could not find a valid walking path.");
-                yield break;
-            }
 
             // initial go to animal
             yield return PawnActions.WalkToPet(this, LocomotionUrgency.Jog);

--- a/JoyGivers/JoyBase.cs
+++ b/JoyGivers/JoyBase.cs
@@ -1,0 +1,60 @@
+﻿using RimWorld;
+using System;
+using System.Collections.Generic;
+using Verse;
+using Verse.AI;
+
+namespace AnimalsAreFunContinued.JoyGivers
+{
+    public abstract class JoyBase : JoyGiver
+    {
+        public List<LocalTargetInfo> FindOutsideWalkingPath(Pawn pawn, Pawn animal)
+        {
+            try
+            {
+                if (
+                    FindWalkingDestination(pawn, animal, out IntVec3 walkingDestination) &&
+                    WalkPathFinder.TryFindWalkPath(pawn, walkingDestination, out List<IntVec3> path)
+                )
+                {
+                    List<LocalTargetInfo> retPath = new List<LocalTargetInfo>(path.Count);
+                    for (int pathIndex = 0; pathIndex < path.Count; pathIndex++)
+                    {
+                        retPath.Add(path[pathIndex]);
+                    }
+                    return retPath;
+                }
+            }
+            catch (Exception ex)
+            {
+                AnimalsAreFunContinued.LogError($"An error occurred in FindOutsideWalkingPath(). {ex.Message}");
+                
+            }
+            return new List<LocalTargetInfo>();
+        }
+
+        private static bool FindWalkingDestination(Pawn pawn, Pawn animal, out IntVec3 walkingDestination)
+        {
+            IntVec3 potentialDestination = new();
+            bool CellGoodForWalking(IntVec3 cell)
+            {
+                Map map = animal.MapHeld;
+                return !PawnUtility.KnownDangerAt(cell, map, pawn) &&
+                        !cell.GetTerrain(map).avoidWander &&
+                        cell.Standable(map) &&
+                        !cell.Roofed(map);
+            };
+
+            bool RegionGoodForWalking(Region region) =>
+                 region.Room.PsychologicallyOutdoors &&
+                 !region.IsForbiddenEntirely(animal) &&
+                 !region.IsForbiddenEntirely(pawn) &&
+                 region.TryFindRandomCellInRegionUnforbidden(animal, CellGoodForWalking, out potentialDestination) &&
+                 !potentialDestination.IsForbidden(pawn);
+
+            bool isValidDestination = CellFinder.TryFindClosestRegionWith(animal.GetRegion(), TraverseParms.For(animal), RegionGoodForWalking, 100, out _);
+            walkingDestination = potentialDestination;
+            return isValidDestination;
+        }
+    }
+}

--- a/JoyGivers/WantToPlayFetch.cs
+++ b/JoyGivers/WantToPlayFetch.cs
@@ -1,12 +1,13 @@
 ﻿using AnimalsAreFunContinued.Data;
 using AnimalsAreFunContinued.Validators;
 using RimWorld;
+using System.Collections.Generic;
 using Verse;
 using Verse.AI;
 
 namespace AnimalsAreFunContinued.JoyGivers
 {
-    public class WantToPlayFetch : JoyGiver
+    public class WantToPlayFetch : JoyBase
     {
         public override Job? TryGiveJob(Pawn pawn)
         {
@@ -27,7 +28,16 @@ namespace AnimalsAreFunContinued.JoyGivers
                 return null;
             }
 
-            var job = JobMaker.MakeJob(def.jobDef, null, animal);
+            // load the walking path
+            List<LocalTargetInfo> path = FindOutsideWalkingPath(pawn, animal);
+            if (path.Count == 0)
+            {
+                AnimalsAreFunContinued.LogInfo($"{pawnName} wanted to play fetch with {animalName}, but could not find a valid walking path.");
+                return null;
+            }
+
+            Job? job = JobMaker.MakeJob(def.jobDef, null, animal);
+            job.targetQueueA = path;
             AnimalsAreFunContinued.LogInfo($"{pawnName} is going to play fetch with {animalName}, made PlayFetch job {job}.");
             return job;
         }

--- a/JoyGivers/WantToWalkPet.cs
+++ b/JoyGivers/WantToWalkPet.cs
@@ -1,12 +1,13 @@
 ﻿using AnimalsAreFunContinued.Data;
 using AnimalsAreFunContinued.Validators;
 using RimWorld;
+using System.Collections.Generic;
 using Verse;
 using Verse.AI;
 
 namespace AnimalsAreFunContinued.JoyGivers
 {
-    public class WantToWalkPet : JoyGiver
+    public class WantToWalkPet : JoyBase
     {
         public override Job? TryGiveJob(Pawn pawn)
         {
@@ -27,7 +28,16 @@ namespace AnimalsAreFunContinued.JoyGivers
                 return null;
             }
 
-            var job = JobMaker.MakeJob(def.jobDef, null, animal);
+            // load the walking path
+            List<LocalTargetInfo> path = FindOutsideWalkingPath(pawn, animal);
+            if (path.Count == 0)
+            {
+                AnimalsAreFunContinued.LogInfo($"{pawnName} wanted to for a walk with {animalName}, but could not find a valid walking path.");
+                return null;
+            }
+
+            Job? job = JobMaker.MakeJob(def.jobDef, null, animal);
+            job.targetQueueA = path;
             AnimalsAreFunContinued.LogInfo($"{pawnName} is going for a walk with {animalName}, made WalkPet job {job}.");
             return job;
         }


### PR DESCRIPTION
This PR corrects a bug when a pawn is locked down with their pet and no path is available to the outside. When this occurs, the pawn would start either the WalkPet or PlayFetch job and immediately abort due to not having a walking path available. The pawn would then immediately attempt to start the job again and would end up in a potential endless loop if no other JoyGivers were applicable to the pawn stuck in the loop. This results in a pawn "standing" in place when observed by the user.

The correction was to load the walking path in the JoyGiver before the job starts in the JoyDriver. Now, when this occurs, the pawn will know immediately that the job is not available to them and try something else before re-attempting the same job. If the pawn has nothing else available to do, then the pawn will "wander" instead of "standing".