### PR TITLE
Feature/bonded animals preference

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -6,7 +6,7 @@
   
   <packageId>ColossalFossil.AnimalsAreFunContinued</packageId>
 
-  <modVersion IgnoreIfNoMatchingField="True">1.6.1</modVersion>
+  <modVersion IgnoreIfNoMatchingField="True">1.6.2</modVersion>
 
   <url>https://steamcommunity.com/workshop/filedetails/?id=3245454244</url>
   

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -61,6 +61,7 @@ namespace AnimalsAreFunContinued
             ShowGapLine(listingStandard, gapSizeSmall);
 
             ShowCheckbox(listingStandard, "ShowDebugMessages", ref Settings.ShowDebugMessages);
+            Settings.CacheExpirationTimeout = ShowSlider(listingStandard, "CacheExpirationTimeout", Settings.CacheExpirationTimeout, Settings.CacheExpirationTimeoutMinRange, Settings.CacheExpirationTimeoutMaxRange);
             if (ShowButton(listingStandard, "Reset", "ResetToDefaults"))
             {
                 Settings.ResetToDefaults();
@@ -91,6 +92,11 @@ namespace AnimalsAreFunContinued
         {
             listingStandard.Label(labelName.Translate(FormatPercent(value)));
             return listingStandard.Slider(value, min, max);
+        }
+        private static int ShowSlider(Listing_Standard listingStandard, string labelName, int value, int min, int max)
+        {
+            listingStandard.Label(labelName.Translate(value));
+            return (int)listingStandard.Slider(value, min, max);
         }
 
         public override string SettingsCategory() => "Animals_are_fun_Continued".Translate();

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -43,7 +43,7 @@ namespace AnimalsAreFunContinued
             ShowCheckbox(listingStandard, "AllowExoticPets", ref Settings.AllowExoticPets, "AllowExoticPetsTooltip");
             Settings.MinConsciousness = ShowSlider(listingStandard, "MinConsciousness", Settings.MinConsciousness, 0.1f, 1);
             Settings.MinMoving = ShowSlider(listingStandard, "MinMoving", Settings.MinMoving, 0.1f, 1);
-            Settings.MaxBodySize = ShowSlider(listingStandard, "MaxBodySize", Settings.MaxBodySize, 0.1f, 1);
+            Settings.MaxBodySize = ShowSlider(listingStandard, "MaxBodySize", Settings.MaxBodySize, 0.1f, Settings.MaxBodySizeRange);
             Settings.MaxWildness = ShowSlider(listingStandard, "MaxWildness", Settings.MaxWildness, 0.1f, 1);
             ShowGap(listingStandard, gapSizeLarge);
 

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -107,9 +107,7 @@ namespace AnimalsAreFunContinued
         private static int ShowSlider(Listing_Standard listingStandard, string labelName, int value, int min, int max, string? tooltipName = null)
         {
 #if V1_6BIN || V1_5BIN || V1_4BIN || RESOURCES
-            //return (int)listingStandard.SliderLabeled(labelName.Translate(value), value, min, max, _sliderLabelWidth, tooltipName?.Translate());
-            listingStandard.Label(labelName.Translate(value));
-            return (int)listingStandard.Slider(value, min, max);
+            return (int)listingStandard.SliderLabeled(labelName.Translate(value), value, min, max, _sliderLabelWidth, tooltipName?.Translate());
 #elif V1_3BIN || V1_2BIN || V1_1BIN
             listingStandard.Label(labelName.Translate(value));
             return (int)listingStandard.Slider(value, min, max);

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -1,4 +1,4 @@
-﻿using RimWorld;
+using RimWorld;
 using System.Runtime.CompilerServices;
 using UnityEngine;
 using Verse;
@@ -8,6 +8,7 @@ namespace AnimalsAreFunContinued
     public class AnimalsAreFunContinued : Mod
     {
         private Rect _scrollRegion = new(0f, 0f, 500f, 9001f);
+        private const float _sliderLabelWidth = 0.4f;
         private Vector2 _scrollPosition;
 
         public AnimalsAreFunContinued(ModContentPack content) : base(content)
@@ -61,7 +62,8 @@ namespace AnimalsAreFunContinued
             ShowGapLine(listingStandard, gapSizeSmall);
 
             ShowCheckbox(listingStandard, "ShowDebugMessages", ref Settings.ShowDebugMessages);
-            Settings.CacheExpirationTimeout = ShowSlider(listingStandard, "CacheExpirationTimeout", Settings.CacheExpirationTimeout, Settings.CacheExpirationTimeoutMinRange, Settings.CacheExpirationTimeoutMaxRange);
+            Settings.CacheExpirationTimeout = ShowSlider(listingStandard, "CacheExpirationTimeout", Settings.CacheExpirationTimeout, Settings.CacheExpirationTimeoutMinRange, Settings.CacheExpirationTimeoutMaxRange, "CacheExpirationTimeoutTooltip");
+            ShowGap(listingStandard, gapSizeSmall);
             if (ShowButton(listingStandard, "Reset", "ResetToDefaults"))
             {
                 Settings.ResetToDefaults();
@@ -88,15 +90,27 @@ namespace AnimalsAreFunContinued
             ShowGap(listingStandard, gapSize);
         }
         private static Rect ShowLabel(Listing_Standard listingStandard, string labelName) => listingStandard.Label(labelName.Translate());
-        private static float ShowSlider(Listing_Standard listingStandard, string labelName, float value, float min, float max)
+        private static float ShowSlider(Listing_Standard listingStandard, string labelName, float value, float min, float max, string? tooltipName = null)
         {
+#if V1_6BIN || V1_5BIN || V1_4BIN || RESOURCES
+            return listingStandard.SliderLabeled(labelName.Translate(FormatPercent(value)), value, min, max, _sliderLabelWidth, tooltipName?.Translate());
+#elif V1_3BIN || V1_2BIN || V1_1BIN
             listingStandard.Label(labelName.Translate(FormatPercent(value)));
             return listingStandard.Slider(value, min, max);
+#else
+    #error "Unsupported build configuration."
+#endif
         }
-        private static int ShowSlider(Listing_Standard listingStandard, string labelName, int value, int min, int max)
+        private static int ShowSlider(Listing_Standard listingStandard, string labelName, int value, int min, int max, string? tooltipName = null)
         {
+#if V1_6BIN || V1_5BIN || V1_4BIN || RESOURCES
+            return (int)listingStandard.SliderLabeled(labelName.Translate(value), value, min, max, _sliderLabelWidth, tooltipName?.Translate());
+#elif V1_3BIN || V1_2BIN || V1_1BIN
             listingStandard.Label(labelName.Translate(value));
             return (int)listingStandard.Slider(value, min, max);
+#else
+    #error "Unsupported build configuration."
+#endif
         }
 
         public override string SettingsCategory() => "Animals_are_fun_Continued".Translate();

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -42,11 +42,14 @@ namespace AnimalsAreFunContinued
 
             ShowCheckbox(listingStandard, "MustBeCute", ref Settings.MustBeCute, "MustBeCuteTooltip");
             ShowCheckbox(listingStandard, "AllowExoticPets", ref Settings.AllowExoticPets, "AllowExoticPetsTooltip");
-            Settings.MinConsciousness = ShowSlider(listingStandard, "MinConsciousness", Settings.MinConsciousness, 0.1f, 1);
-            Settings.MinMoving = ShowSlider(listingStandard, "MinMoving", Settings.MinMoving, 0.1f, 1);
+            Settings.MinConsciousness = ShowSlider(listingStandard, "MinConsciousness", Settings.MinConsciousness, 0.1f, 1.0f);
+            Settings.MinMoving = ShowSlider(listingStandard, "MinMoving", Settings.MinMoving, 0.1f, 1.0f);
             Settings.MaxBodySize = ShowSlider(listingStandard, "MaxBodySize", Settings.MaxBodySize, 0.1f, Settings.MaxBodySizeRange);
-            Settings.MaxWildness = ShowSlider(listingStandard, "MaxWildness", Settings.MaxWildness, 0.1f, 1);
-            ShowGap(listingStandard, gapSizeLarge);
+            Settings.MaxWildness = ShowSlider(listingStandard, "MaxWildness", Settings.MaxWildness, 0.1f, 1.0f);
+            Settings.BondedAnimalsPreference = ShowSlider(listingStandard, "BondedAnimalsPreference", Settings.BondedAnimalsPreference, 0.0f, 1.0f, "BondedAnimalsPreferenceTooltip");
+            ShowSliderLabels(listingStandard, "DontCare", "OnlyBonded");
+            ShowSliderCheckbox(listingStandard, "BondedAnimalsMustBeCute", ref Settings.BondedAnimalsMustBeCute, "BondedAnimalsMustBeCuteTooltip");
+            ShowGap(listingStandard, gapSizeSmall);
 
             /* Experimental */
             ShowLabel(listingStandard, "ExperimentalCategory");
@@ -104,13 +107,55 @@ namespace AnimalsAreFunContinued
         private static int ShowSlider(Listing_Standard listingStandard, string labelName, int value, int min, int max, string? tooltipName = null)
         {
 #if V1_6BIN || V1_5BIN || V1_4BIN || RESOURCES
-            return (int)listingStandard.SliderLabeled(labelName.Translate(value), value, min, max, _sliderLabelWidth, tooltipName?.Translate());
+            //return (int)listingStandard.SliderLabeled(labelName.Translate(value), value, min, max, _sliderLabelWidth, tooltipName?.Translate());
+            listingStandard.Label(labelName.Translate(value));
+            return (int)listingStandard.Slider(value, min, max);
 #elif V1_3BIN || V1_2BIN || V1_1BIN
             listingStandard.Label(labelName.Translate(value));
             return (int)listingStandard.Slider(value, min, max);
 #else
     #error "Unsupported build configuration."
 #endif
+        }
+        private static void ShowSliderLabels(Listing_Standard listingStandard, string minRangeLabel, string maxRangeLabel)
+        {
+            const float labelLeftMargin = 10.0f;
+            const float labelRightMargin = 11.0f;
+            float labelStartX = listingStandard.listingRect.width * _sliderLabelWidth;
+            float labelWidth = (listingStandard.listingRect.width - labelStartX) / 2;
+            const float labelHeight = 30.0f;
+
+            Listing_Standard labelListingStandardLeft = new() { maxOneColumn = true };
+            Rect labelRegionLeft = new(labelStartX + labelLeftMargin, listingStandard.curY, labelWidth, labelHeight);
+            labelListingStandardLeft.Begin(labelRegionLeft);
+            GenUI.SetLabelAlign(TextAnchor.MiddleLeft);
+            labelListingStandardLeft.Label(minRangeLabel.Translate());
+            GenUI.ResetLabelAlign();
+            labelListingStandardLeft.End();
+
+            Listing_Standard labelListingStandardRight = new() { maxOneColumn = true };
+            Rect labelRegionRight = new(labelStartX + labelWidth - labelRightMargin, listingStandard.curY, labelWidth, labelHeight);
+            labelListingStandardRight.Begin(labelRegionRight);
+            GenUI.SetLabelAlign(TextAnchor.MiddleRight);
+            labelListingStandardRight.Label(maxRangeLabel.Translate());
+            GenUI.ResetLabelAlign();
+            listingStandard.curY += labelListingStandardRight.CurHeight;
+            labelListingStandardRight.End();
+        }
+        private static void ShowSliderCheckbox(Listing_Standard listingStandard, string labelName, ref bool value, string? tooltipName = null)
+        {
+            const float checkboxMarginLeft = 110.0f;
+            const float checkboxMarginRight = 14.0f;
+            float checkboxStartX = listingStandard.listingRect.width * _sliderLabelWidth + checkboxMarginLeft;
+            float checkboxWidth = listingStandard.listingRect.width - checkboxStartX - checkboxMarginRight;
+            const float checkboxHeight = 30.0f;
+
+            Listing_Standard checkboxListingStandard = new() { maxOneColumn = true };
+            Rect checkboxRegion = new(checkboxStartX, listingStandard.curY, checkboxWidth, checkboxHeight);
+            checkboxListingStandard.Begin(checkboxRegion);
+            checkboxListingStandard.CheckboxLabeled(labelName.Translate(), ref value, tooltipName?.Translate());
+            listingStandard.curY += checkboxListingStandard.CurHeight;
+            checkboxListingStandard.End();
         }
 
         public override string SettingsCategory() => "Animals_are_fun_Continued".Translate();

--- a/AnimalsAreFunContinued.cs
+++ b/AnimalsAreFunContinued.cs
@@ -39,6 +39,8 @@ namespace AnimalsAreFunContinued
             ShowLabel(listingStandard, "RequirementsCategory");
             ShowGapLine(listingStandard, gapSizeSmall);
 
+            ShowCheckbox(listingStandard, "MustBeCute", ref Settings.MustBeCute, "MustBeCuteTooltip");
+            ShowCheckbox(listingStandard, "AllowExoticPets", ref Settings.AllowExoticPets, "AllowExoticPetsTooltip");
             Settings.MinConsciousness = ShowSlider(listingStandard, "MinConsciousness", Settings.MinConsciousness, 0.1f, 1);
             Settings.MinMoving = ShowSlider(listingStandard, "MinMoving", Settings.MinMoving, 0.1f, 1);
             Settings.MaxBodySize = ShowSlider(listingStandard, "MaxBodySize", Settings.MaxBodySize, 0.1f, 1);
@@ -49,9 +51,7 @@ namespace AnimalsAreFunContinued
             ShowLabel(listingStandard, "ExperimentalCategory");
             ShowGapLine(listingStandard, gapSizeSmall);
 
-            ShowCheckbox(listingStandard, "MustBeCute", ref Settings.MustBeCute, "MustBeCuteTooltip");
             ShowCheckbox(listingStandard, "AllowHumanLike", ref Settings.AllowHumanLike, "AllowHumanLikeTooltip");
-            ShowCheckbox(listingStandard, "AllowExoticPets", ref Settings.AllowExoticPets, "AllowExoticPetsTooltip");
             ShowCheckbox(listingStandard, "AllowCrossFaction", ref Settings.AllowCrossFaction, "AllowCrossFactionTooltip");
             ShowCheckbox(listingStandard, "AllowNonColonist", ref Settings.AllowNonColonist, "AllowNonColonistTooltip");
             ShowGap(listingStandard, gapSizeLarge);

--- a/AnimalsAreFunContinued.csproj
+++ b/AnimalsAreFunContinued.csproj
@@ -5,7 +5,7 @@
     <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <Title>Animals Are Fun! (Continued)</Title>
-    <Version>1.6.1</Version>
+    <Version>1.6.2</Version>
     <Authors>ColossalFossil</Authors>
     <Product>Animals Are Fun! (Continued)</Product>
     <Description>A RimWorld mod that allows your pawns to play fetch or go for a walk with your pets.</Description>

--- a/Data/AnimalCache.cs
+++ b/Data/AnimalCache.cs
@@ -66,7 +66,7 @@ namespace AnimalsAreFunContinued.Data
                     return false;
                 }
                 
-                if (!AvailabilityChecks.WillAnimalEnjoyPlayingOutside(pawnName, animal, false, out string? reason))
+                if (!AvailabilityChecks.WillAnimalEnjoyPlayingOutside(pawn, animal, false, out string? reason))
                 {
                     if (reason != null) AnimalsAreFunContinued.LogInfo(reason);
                     return false;

--- a/Data/AnimalCache.cs
+++ b/Data/AnimalCache.cs
@@ -105,7 +105,7 @@ namespace AnimalsAreFunContinued.Data
                 }
                 else if (Settings.BondedAnimalsPreference >= 1.0f)
                 {
-                    AnimalsAreFunContinued.LogInfo($"{pawnName} only wants to play with non-bonded animals and is no longer interested.");
+                    AnimalsAreFunContinued.LogInfo($"{pawnName} only wants to play with bonded animals and is no longer interested.");
                     return null;
                 }
 

--- a/Data/AnimalCache.cs
+++ b/Data/AnimalCache.cs
@@ -10,7 +10,6 @@ namespace AnimalsAreFunContinued.Data
 {
     public static class AnimalCache
     {
-        private const int ExpirationTimeout = 1800;
         private static readonly Dictionary<int, AnimalCacheKey> _availableAnimals = [];
 
         public static IEnumerable<Thing> GetAvailableAnimals(Map map)
@@ -25,7 +24,7 @@ namespace AnimalsAreFunContinued.Data
                                               where (animal as Pawn)?.def?.race?.Animal == true &&
                                                     animal.Faction != null
                                               select animal) ?? [];
-                int expirationTick = currentTick + ExpirationTimeout;
+                int expirationTick = currentTick + Settings.CacheExpirationTimeout;
 
                 if (hasExistingAnimalListForMap)
                 {

--- a/Languages/English/Keyed/Translations.xml
+++ b/Languages/English/Keyed/Translations.xml
@@ -9,9 +9,14 @@
   <AllowNonColonist>Allow non-colonist</AllowNonColonist>
   <AllowNonColonistTooltip>Allows visitors from other factions to interact with your animals.</AllowNonColonistTooltip>
   <Animals_are_fun_Continued>Animals are fun! (Continued)</Animals_are_fun_Continued>
+  <BondedAnimalsMustBeCute>Bonded Animals Must Be Cute</BondedAnimalsMustBeCute>
+  <BondedAnimalsMustBeCuteTooltip>When enabled and a pawn prefers to play with a bonded animal, only cute animals will be considered.</BondedAnimalsMustBeCuteTooltip>
+  <BondedAnimalsPreference>Bonded Animals Preference</BondedAnimalsPreference>
+  <BondedAnimalsPreferenceTooltip>This is the chance that a pawn will prefer to play with a bonded animal before choosing a non-bonded animal.</BondedAnimalsPreferenceTooltip>
   <CacheExpirationTimeout>Cache Expiration Timeout ({0} ticks)</CacheExpirationTimeout>
   <CacheExpirationTimeoutTooltip>How long before the cache expires and is recalculated. Too low of a value may cause performance problems on slower computers. Higher values will cause a delay before pawns are able to play with animals that have recently entered the map.</CacheExpirationTimeoutTooltip>
   <DebuggingCategory>Debugging:</DebuggingCategory>
+  <DontCare>Don't Care</DontCare>
   <ExperimentalCategory>Experimental:</ExperimentalCategory>
   <MaxBodySize>Max. body size ({0}cm)</MaxBodySize>
   <MaxWildness>Max. wildness ({0}%)</MaxWildness>
@@ -19,6 +24,7 @@
   <MinMoving>Min. moving ({0}%)</MinMoving>
   <MustBeCute>Must be cute</MustBeCute>
   <MustBeCuteTooltip>Only play with or walk nuzzling animals. WARNING: Do not turn this off unless your have a very large penned in area or you have a mod that allows you teach zoning rules to any animal.</MustBeCuteTooltip>
+  <OnlyBonded>Only Bonded</OnlyBonded>
   <RequirementsCategory>Requirements:</RequirementsCategory>
   <ResetToDefaults>Reset all settings to defaults</ResetToDefaults>
   <Reset>Reset</Reset>

--- a/Languages/English/Keyed/Translations.xml
+++ b/Languages/English/Keyed/Translations.xml
@@ -10,6 +10,7 @@
   <AllowNonColonistTooltip>Allows visitors from other factions to interact with your animals.</AllowNonColonistTooltip>
   <Animals_are_fun_Continued>Animals are fun! (Continued)</Animals_are_fun_Continued>
   <CacheExpirationTimeout>Cache Expiration Timeout ({0} ticks)</CacheExpirationTimeout>
+  <CacheExpirationTimeoutTooltip>How long before the cache expires and is recalculated. Too low of a value may cause performance problems on slower computers. Higher values will cause a delay before pawns are able to play with animals that have recently entered the map.</CacheExpirationTimeoutTooltip>
   <DebuggingCategory>Debugging:</DebuggingCategory>
   <ExperimentalCategory>Experimental:</ExperimentalCategory>
   <MaxBodySize>Max. body size ({0}cm)</MaxBodySize>

--- a/Languages/English/Keyed/Translations.xml
+++ b/Languages/English/Keyed/Translations.xml
@@ -9,6 +9,7 @@
   <AllowNonColonist>Allow non-colonist</AllowNonColonist>
   <AllowNonColonistTooltip>Allows visitors from other factions to interact with your animals.</AllowNonColonistTooltip>
   <Animals_are_fun_Continued>Animals are fun! (Continued)</Animals_are_fun_Continued>
+  <CacheExpirationTimeout>Cache Expiration Timeout ({0} ticks)</CacheExpirationTimeout>
   <DebuggingCategory>Debugging:</DebuggingCategory>
   <ExperimentalCategory>Experimental:</ExperimentalCategory>
   <MaxBodySize>Max. body size ({0}cm)</MaxBodySize>

--- a/Settings.cs
+++ b/Settings.cs
@@ -18,6 +18,9 @@ namespace AnimalsAreFunContinued
         private const bool defaultAllowNonColonist = false;
 
         private const bool defaultShowDebugMessages = false;
+        private const int defaultCacheExpirationTimeout = 1800;
+        public static readonly int CacheExpirationTimeoutMinRange = 60;
+        public static readonly int CacheExpirationTimeoutMaxRange = 5400;
 
         public static float MinConsciousness = defaultMinConsciousness;
         public static float MinMoving = defaultMinMoving;
@@ -31,6 +34,7 @@ namespace AnimalsAreFunContinued
         public static bool AllowNonColonist = defaultAllowNonColonist;
 
         public static bool ShowDebugMessages = defaultShowDebugMessages;
+        public static int CacheExpirationTimeout = defaultCacheExpirationTimeout;
 
         public override void ExposeData()
         {
@@ -48,11 +52,13 @@ namespace AnimalsAreFunContinued
             Scribe_Values.Look(ref AllowNonColonist, "AllowNonColonist", defaultAllowNonColonist);
 
             Scribe_Values.Look(ref ShowDebugMessages, "ShowDebugMessages", defaultShowDebugMessages);
+            Scribe_Values.Look(ref CacheExpirationTimeout, "CacheExpirationTimeout", defaultCacheExpirationTimeout);
 
             MinConsciousness = Mathf.Clamp(MinConsciousness, 0.1f, 1);
             MinMoving = Mathf.Clamp(MinMoving, 0.1f, 1);
             MaxBodySize = Mathf.Clamp(MaxBodySize, 0.01f, MaxBodySizeRange);
             MaxWildness = Mathf.Clamp(MaxWildness, 0.1f, 1);
+            CacheExpirationTimeout = Mathf.Clamp(CacheExpirationTimeout, CacheExpirationTimeoutMinRange, CacheExpirationTimeoutMaxRange);
         }
 
         public static void ResetToDefaults()
@@ -69,6 +75,7 @@ namespace AnimalsAreFunContinued
             AllowNonColonist = defaultAllowNonColonist;
 
             ShowDebugMessages = defaultShowDebugMessages;
+            CacheExpirationTimeout = defaultCacheExpirationTimeout;
         }
     }
 }

--- a/Settings.cs
+++ b/Settings.cs
@@ -8,6 +8,7 @@ namespace AnimalsAreFunContinued
         private const float defaultMinConsciousness = 0.6f;
         private const float defaultMinMoving = 0.7f;
         private const float defaultMaxBodySize = 1.6f;
+        public static readonly float MaxBodySizeRange = 5.0f;
         private const float defaultMaxWildness = 0.8f;
         private const bool defaultMustBeCute = true;
 
@@ -50,7 +51,7 @@ namespace AnimalsAreFunContinued
 
             MinConsciousness = Mathf.Clamp(MinConsciousness, 0.1f, 1);
             MinMoving = Mathf.Clamp(MinMoving, 0.1f, 1);
-            MaxBodySize = Mathf.Clamp(MaxBodySize, 0.01f, 5);
+            MaxBodySize = Mathf.Clamp(MaxBodySize, 0.01f, MaxBodySizeRange);
             MaxWildness = Mathf.Clamp(MaxWildness, 0.1f, 1);
         }
 

--- a/Settings.cs
+++ b/Settings.cs
@@ -11,30 +11,30 @@ namespace AnimalsAreFunContinued
         public static readonly float MaxBodySizeRange = 5.0f;
         private const float defaultMaxWildness = 0.8f;
         private const bool defaultMustBeCute = true;
-
         private const bool defaultAllowHumanLike = false;
         private const bool defaultAllowExoticPets = false;
         private const bool defaultAllowCrossFaction = false;
         private const bool defaultAllowNonColonist = false;
-
         private const bool defaultShowDebugMessages = false;
         private const int defaultCacheExpirationTimeout = 1800;
+        private const float defaultBondedAnimalsPreference = 0.5f;
+        private const bool defaultBondedAnimalsMustBeCute = false;
+
         public static readonly int CacheExpirationTimeoutMinRange = 60;
         public static readonly int CacheExpirationTimeoutMaxRange = 5400;
-
         public static float MinConsciousness = defaultMinConsciousness;
         public static float MinMoving = defaultMinMoving;
         public static float MaxBodySize = defaultMaxBodySize;
         public static float MaxWildness = defaultMaxWildness;
         public static bool MustBeCute = defaultMustBeCute;
-
         public static bool AllowHumanLike = defaultAllowHumanLike;
         public static bool AllowExoticPets = defaultAllowExoticPets;
         public static bool AllowCrossFaction = defaultAllowCrossFaction;
         public static bool AllowNonColonist = defaultAllowNonColonist;
-
         public static bool ShowDebugMessages = defaultShowDebugMessages;
         public static int CacheExpirationTimeout = defaultCacheExpirationTimeout;
+        public static float BondedAnimalsPreference = defaultBondedAnimalsPreference;
+        public static bool BondedAnimalsMustBeCute = defaultBondedAnimalsMustBeCute;
 
         public override void ExposeData()
         {
@@ -45,20 +45,21 @@ namespace AnimalsAreFunContinued
             Scribe_Values.Look(ref MaxBodySize, "MaxBodySize", defaultMaxBodySize);
             Scribe_Values.Look(ref MaxWildness, "MaxWildness", defaultMaxWildness);
             Scribe_Values.Look(ref MustBeCute, "MustBeCute", defaultMustBeCute);
-
             Scribe_Values.Look(ref AllowHumanLike, "AllowHumanLike", defaultAllowHumanLike);
             Scribe_Values.Look(ref AllowExoticPets, "AllowExoticPets", defaultAllowExoticPets);
             Scribe_Values.Look(ref AllowCrossFaction, "AllowCrossFaction", defaultAllowCrossFaction);
             Scribe_Values.Look(ref AllowNonColonist, "AllowNonColonist", defaultAllowNonColonist);
-
             Scribe_Values.Look(ref ShowDebugMessages, "ShowDebugMessages", defaultShowDebugMessages);
             Scribe_Values.Look(ref CacheExpirationTimeout, "CacheExpirationTimeout", defaultCacheExpirationTimeout);
+            Scribe_Values.Look(ref BondedAnimalsPreference, "BondedAnimalsPreference", defaultBondedAnimalsPreference);
+            Scribe_Values.Look(ref BondedAnimalsMustBeCute, "BondedAnimalsMustBeCute", defaultBondedAnimalsMustBeCute);
 
-            MinConsciousness = Mathf.Clamp(MinConsciousness, 0.1f, 1);
-            MinMoving = Mathf.Clamp(MinMoving, 0.1f, 1);
+            MinConsciousness = Mathf.Clamp(MinConsciousness, 0.1f, 1.0f);
+            MinMoving = Mathf.Clamp(MinMoving, 0.1f, 1.0f);
             MaxBodySize = Mathf.Clamp(MaxBodySize, 0.01f, MaxBodySizeRange);
-            MaxWildness = Mathf.Clamp(MaxWildness, 0.1f, 1);
+            MaxWildness = Mathf.Clamp(MaxWildness, 0.1f, 1.0f);
             CacheExpirationTimeout = Mathf.Clamp(CacheExpirationTimeout, CacheExpirationTimeoutMinRange, CacheExpirationTimeoutMaxRange);
+            BondedAnimalsPreference = Mathf.Clamp(BondedAnimalsPreference, 0.0f, 1.0f);
         }
 
         public static void ResetToDefaults()
@@ -68,14 +69,14 @@ namespace AnimalsAreFunContinued
             MaxBodySize = defaultMaxBodySize;
             MaxWildness = defaultMaxWildness;
             MustBeCute = defaultMustBeCute;
-
             AllowHumanLike = defaultAllowHumanLike;
             AllowExoticPets = defaultAllowExoticPets;
             AllowCrossFaction = defaultAllowCrossFaction;
             AllowNonColonist = defaultAllowNonColonist;
-
             ShowDebugMessages = defaultShowDebugMessages;
             CacheExpirationTimeout = defaultCacheExpirationTimeout;
+            BondedAnimalsPreference = defaultBondedAnimalsPreference;
+            BondedAnimalsMustBeCute = defaultBondedAnimalsMustBeCute;
         }
     }
 }

--- a/Toils/PawnActions.cs
+++ b/Toils/PawnActions.cs
@@ -175,7 +175,6 @@ namespace AnimalsAreFunContinued.Toils
             Pawn pawn = jobDriver.pawn;
             Pawn animal = job.GetTarget(TargetIndex.B).Pawn;
             int? animalCurrentJobId = jobDriver.InteractiveTargetCurrentJobId;
-            string pawnName = FormatLog.PawnName(pawn);
 
             if (!AvailabilityChecks.WillPawnEnjoyPlayingOutside(pawn, true, out string? reason))
             {
@@ -184,7 +183,7 @@ namespace AnimalsAreFunContinued.Toils
                 return true;
             }
 
-            if (!AvailabilityChecks.WillAnimalEnjoyPlayingOutside(pawnName, animal, true, out reason))
+            if (!AvailabilityChecks.WillAnimalEnjoyPlayingOutside(pawn, animal, true, out reason))
             {
                 if (reason != null) AnimalsAreFunContinued.LogInfo(reason);
                 EndAnimalJobOnFail(animal, animalCurrentJobId);


### PR DESCRIPTION
This PR adds the ability for pawns to prefer bonded animals over normal animals. If no bonded animals are present for the pawn, then non-bonded animals will be searched for next, unless the prefer bonded animals is set to 100%. By default, bonded animals do not need to be cute unless the Bonded Animals Must Be Cute is set in the mod settings.

The Cuteness and exotic settings were moved to the normal requirements section as they have been proven to work correctly. The Max Body Size range was incorrectly capped at 100mm. It has been fixed to allow animals of up to 500mm in size. Cache expiration has also been added as a debug setting. 